### PR TITLE
fix: update NFS setup script to work for multiple gateways

### DIFF
--- a/modules/protocol_gateways/setup_nfs.sh
+++ b/modules/protocol_gateways/setup_nfs.sh
@@ -1,18 +1,91 @@
-# create interface group
-weka nfs interface-group add ${interface_group_name} NFS
+weka local ps
+
+function create_interface_group() {
+  if weka nfs interface-group | grep ${interface_group_name}; then
+    echo "$(date -u): interface group ${interface_group_name} already exists"
+    return
+  fi
+  echo "$(date -u): creating interface group"
+  weka nfs interface-group add ${interface_group_name} NFS
+  echo "$(date -u): interface group ${interface_group_name} created"
+}
+
+function wait_for_weka_fs(){
+  filesystem_name="default"
+  max_retries=30 # 30 * 10 = 5 minutes
+  for (( i=0; i < max_retries; i++ )); do
+    if [ "$(weka fs | grep -c $filesystem_name)" -ge 1 ]; then
+      echo "$(date -u): weka filesystem $filesystem_name is up"
+      break
+    fi
+    echo "$(date -u): waiting for weka filesystem $filesystem_name to be up"
+    sleep 10
+  done
+  if (( i > max_retries )); then
+      echo "$(date -u): timeout: weka filesystem $filesystem_name is not up after $max_retries attempts."
+      return 1
+  fi
+}
+
+function create_client_group() {
+  if weka nfs client-group | grep ${client_group_name}; then
+    echo "$(date -u): client group ${client_group_name} already exists"
+    return
+  fi
+  echo "$(date -u): creating client group"
+  weka nfs client-group add ${client_group_name}
+  weka nfs rules add dns ${client_group_name} *
+  wait_for_weka_fs || return 1
+  weka nfs permission add default ${client_group_name}
+  echo "$(date -u): client group ${client_group_name} created"
+}
+
+# make sure weka cluster is already up
+max_retries=60 # 60 * 30 = 30 minutes
+for (( i=0; i < max_retries; i++ )); do
+  if [ $(weka status | grep 'status: OK' | wc -l) -ge 1 ]; then
+    echo "$(date -u): weka cluster is up"
+    break
+  fi
+  echo "$(date -u): waiting for weka cluster to be up"
+  sleep 30
+done
+if (( i > max_retries )); then
+    echo "$(date -u): timeout: weka cluster is not up after $max_retries attempts."
+    exit 1
+fi
+
+# create interface group if not exists
+create_interface_group || true
+
+current_mngmnt_ip=$(weka local resources | grep 'Management IPs' | awk '{print $NF}')
 # get container id
-container_id=$(weka cluster container | grep frontend0 | grep ${gateways_name} | grep UP | awk '{print $1}')
+max_retries=12 # 12 * 10 = 2 minutes
+for ((i=0; i<max_retries; i++)); do
+  container_id=$(weka cluster container | grep frontend0 | grep ${gateways_name} | grep $current_mngmnt_ip | grep UP | awk '{print $1}')
+  if [ -n "$container_id" ]; then
+      echo "$(date -u): frontend0 container id: $container_id"
+      break
+  fi
+  echo "$(date -u): waiting for frontend0 container to be up"
+  sleep 10
+done
+
+if [ -z "$container_id" ]; then
+  echo "$(date -u): Failed to get the frontend0 container ID."
+  exit 1
+fi
+
 # get device to use
-port=$(ip -o -f inet addr show | grep -m 1 eth | awk '{print $2}')
+port=$(ip -o -f inet addr show | grep "$current_mngmnt_ip/"| awk '{print $2}')
 
 weka nfs interface-group port add ${interface_group_name} $container_id $port
 # show interface group
 weka nfs interface-group
 
-weka nfs client-group add ${client_group_name}
-weka nfs rules add dns ${client_group_name} *
-weka nfs permission add default ${client_group_name}
+# create client group if not exists and add rules / premissions
+create_client_group || true
+
 weka nfs client-group
 
-weka local ps
 echo "$(date -u): nfs setup complete"

--- a/protocol-gateways.tf
+++ b/protocol-gateways.tf
@@ -43,7 +43,7 @@ module "protocol_gateways" {
   disk_size                  = var.protocol_gateway_disk_size
   frontend_num               = var.protocol_gateway_frontend_num
 
-  depends_on = [azurerm_linux_virtual_machine_scale_set.vmss]
+  depends_on = [azurerm_linux_virtual_machine_scale_set.vmss, azurerm_key_vault_secret.get_weka_io_token]
 }
 
 resource "null_resource" "clean_backend_ips_for_protocol_gateways" {


### PR DESCRIPTION
```
weka@ks-test-protocol-gateway-vmss000003:~$ weka cluster container
CONTAINER ID  HOSTNAME                             CONTAINER  IPS        STATUS  RELEASE  FAILURE DOMAIN    CORES  MEMORY   LAST FAILURE  UPTIME
0             ks-test-backend000002                drives0    10.0.2.14  UP      4.2.1    b9394ba4371529f2  1      1.49 GB                0:08:52h
1             ks-test-backend000002                compute0   10.0.2.14  UP      4.2.1    b9394ba4371529f2  1      31 GB                  0:08:46h
2             ks-test-backend000002                frontend0  10.0.2.14  UP      4.2.1    b9394ba4371529f2  1      1.47 GB                0:08:41h
3             ks-test-backend000006                drives0    10.0.2.30  UP      4.2.1    b147659396400192  1      1.49 GB                0:08:47h
4             ks-test-backend000006                compute0   10.0.2.30  UP      4.2.1    b147659396400192  1      31 GB                  0:08:41h
5             ks-test-backend000006                frontend0  10.0.2.30  UP      4.2.1    b147659396400192  1      1.47 GB                0:08:37h
6             ks-test-backend000007                drives0    10.0.2.34  UP      4.2.1    15236e31eba9f20b  1      1.49 GB                0:08:26h
7             ks-test-backend000007                compute0   10.0.2.34  UP      4.2.1    15236e31eba9f20b  1      31 GB                  0:08:21h
8             ks-test-backend000007                frontend0  10.0.2.34  UP      4.2.1    15236e31eba9f20b  1      1.47 GB                0:08:16h
9             ks-test-backend000004                drives0    10.0.2.22  UP      4.2.1    4d5ac5f229498d6c  1      1.49 GB                0:08:24h
10            ks-test-backend000004                compute0   10.0.2.22  UP      4.2.1    4d5ac5f229498d6c  1      31 GB                  0:08:18h
11            ks-test-backend000004                frontend0  10.0.2.22  UP      4.2.1    4d5ac5f229498d6c  1      1.47 GB                0:08:13h
12            ks-test-backend000001                drives0    10.0.2.10  UP      4.2.1    58dc8a2b3e3d466a  1      1.49 GB                0:07:50h
13            ks-test-backend000001                compute0   10.0.2.10  UP      4.2.1    58dc8a2b3e3d466a  1      31 GB                  0:07:44h
14            ks-test-backend000001                frontend0  10.0.2.10  UP      4.2.1    58dc8a2b3e3d466a  1      1.47 GB                0:07:39h
15            ks-test-backend000005                drives0    10.0.2.26  UP      4.2.1    f93da75e14a4e6c2  1      1.49 GB                0:07:23h
16            ks-test-backend000005                compute0   10.0.2.26  UP      4.2.1    f93da75e14a4e6c2  1      31 GB                  0:07:17h
17            ks-test-backend000005                frontend0  10.0.2.26  UP      4.2.1    f93da75e14a4e6c2  1      1.47 GB                0:07:13h
18            ks-test-protocol-gateway-vmss000004  frontend0  10.0.2.65  UP      4.2.1    3377645a4fe59b26  1      1.47 GB                0:06:25h
19            ks-test-protocol-gateway-vmss000006  frontend0  10.0.2.71  UP      4.2.1    039fac464946136a  1      1.47 GB                0:06:25h
20            ks-test-protocol-gateway-vmss000003  frontend0  10.0.2.62  UP      4.2.1    85e27b80ba377ea6  1      1.47 GB                0:06:23h
21            ks-test-client-vmss000003            client     10.0.2.44  UP      4.2.1                      1      1.46 GB                0:02:59h
22            ks-test-client-vmss000000            client     10.0.2.38  UP      4.2.1                      1      1.46 GB                0:02:56h
23            ks-test-client-vmss000001            client     10.0.2.40  UP      4.2.1                      1      1.46 GB                33.25s

weka@ks-test-protocol-gateway-vmss000003:~$ weka status
WekaIO v4.2.1 (CLI build 4.2.1)

       cluster: test (1fc04e8e-19ef-4f03-89cc-c2e1ab8a2394)
        status: OK (21 backend containers UP, 6 drives UP)
    protection: 3+2 (Fully protected)
     hot spare: 1 failure domains (965.25 GiB)
 drive storage: 4.71 TiB total
         cloud: connected
       license: Unlicensed

     io status: STARTED 5 minutes ago (21 io-nodes UP, 162 Buckets UP)
    link layer: Ethernet
       clients: 3 connected
         reads: 0 B/s (0 IO/s)
        writes: 0 B/s (0 IO/s)
    operations: 0 ops/s
        alerts: 3 active alerts, use `weka alerts` to list them

weka@ks-test-protocol-gateway-vmss000003:~$ weka nfs interface-group
NAME     SUBNET MASK      GATEWAY          TYPE  STATUS  IPS  PORTS                                                                                                                                                                                                                                                                                 ALLOW MANAGE GIDS
weka-ig  255.255.255.255  255.255.255.255  NFS   OK           [     host_uid: 91465da1-2b92-d65b-5b63-4eb6b963c261,host_id: HostId<18>,port: eth0,status: OK,,host_uid: 69e3c458-e219-11e7-6791-79ca66194731,host_id: HostId<19>,port: eth0,status: OK,,host_uid: f27990ea-bc11-9da3-f3c8-3c07a1e2606f,host_id: HostId<20>,port: eth0,status: OK ]  True
```
clients:
```
weka@ks-test-client-vmss000000:~$ sudo apt-get install nfs-common
weka@ks-test-client-vmss000000:~$ sudo mkdir /mnt/nfs/
weka@ks-test-client-vmss000000:~$ sudo mount -t nfs 10.0.2.65:/default /mnt/nfs/
weka@ks-test-client-vmss000000:~$ mount | grep nfs
10.0.2.65:/default on /mnt/nfs type nfs (rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.0.2.65,mountvers=3,mountport=42005,mountproto=udp,local_lock=none,addr=10.0.2.65)

weka@ks-test-client-vmss000001:~$ sudo mkdir /mnt/nfs/
weka@ks-test-client-vmss000001:~$ sudo mount -t nfs 10.0.2.71:/default /mnt/nfs/
weka@ks-test-client-vmss000001:~$ mount | grep nfs
10.0.2.71:/default on /mnt/nfs type nfs (rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.0.2.71,mountvers=3,mountport=37395,mountproto=udp,local_lock=none,addr=10.0.2.71)

weka@ks-test-client-vmss000003:~$ sudo mkdir /mnt/nfs/
weka@ks-test-client-vmss000003:~$ sudo mount -t nfs 10.0.2.62:/default /mnt/nfs/
weka@ks-test-client-vmss000003:~$ mount | grep nfs
10.0.2.62:/default on /mnt/nfs type nfs (rw,relatime,vers=3,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,mountaddr=10.0.2.62,mountvers=3,mountport=47938,mountproto=udp,local_lock=none,addr=10.0.2.62)
```
