### PR TITLE
fix: set logicapp FUNCTIONS_EXTENSION_VERSION using correct setting

### DIFF
--- a/logic_app.tf
+++ b/logic_app.tf
@@ -40,6 +40,7 @@ resource "azurerm_logic_app_standard" "logic_app_standard" {
   app_service_plan_id        = azurerm_service_plan.logicapp_service_plan.id
   storage_account_name       = azurerm_storage_account.logicapp.name
   storage_account_access_key = azurerm_storage_account.logicapp.primary_access_key
+  version                    = "~4" # sets FUNCTIONS_EXTENSION_VERSION (should be same as for function app)
   identity {
     type = "SystemAssigned"
   }
@@ -56,7 +57,6 @@ resource "azurerm_logic_app_standard" "logic_app_standard" {
     }
   }
   app_settings = {
-    "FUNCTIONS_EXTENSION_VERSION"  = "~4"
     "FUNCTIONS_WORKER_RUNTIME"     = "node"
     "WEBSITE_NODE_DEFAULT_VERSION" = "~18"
     "function_app_key"             = data.azurerm_function_app_host_keys.function_keys.default_function_key


### PR DESCRIPTION
from tf `azurerm_logic_app_standard ` resource [docs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/logic_app_standard): `FUNCTIONS_EXTENSION_VERSION is filled based on version`

I've set it using the wrong way in PR #252  (it worked for me on the second TF apply, but now it failed on first tf apply)